### PR TITLE
Implementing query maps

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,17 @@
+import queryString from 'query-string';
+
+export const queryStringStringify = queryDict => {
+  const queryDictOriginal = queryDict;
+  const queryDictUpdated = {};
+  Object.keys(queryDictOriginal).forEach(key => {
+    if (
+      queryDictOriginal[key] !== undefined &&
+      queryDictOriginal[key] !== '' &&
+      queryDictOriginal[key] !== null
+    ) {
+      queryDictUpdated[key] = queryDictOriginal[key];
+    }
+  });
+
+  return queryString.stringify(queryDictUpdated);
+};


### PR DESCRIPTION
We decided to use query maps instead `getParams` function to convert map to url parameters. It will look so:

```
  const data = await topicService.search({
    search: query,
    type: flag,
    lang: langService.current,
    categories: categoryParams,
    children: parentsById,
    parents: childrenById
  });
```